### PR TITLE
Updated documentation code example

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -24,9 +24,15 @@
 //! Then:
 //!
 //! ```rust
-//! let link_header = "<https://api.github.com/repositories/41986369/contributors?page=2>; rel=\"next\", <https://api.github.com/repositories/41986369/contributors?page=14>; rel=\"last\"";
+//! let link_header = r#"<https://api.github.com/repositories/41986369/contributors?page=2>; rel="next", <https://api.github.com/repositories/41986369/contributors?page=14>; rel="last""#;
 //!
-//! parse_link_header::parse(link_header);
+//! let res = parse_link_header::parse(link_header);
+//! assert!(res.is_ok());
+//!
+//! let val = res.unwrap();
+//! assert_eq!(val.len(), 2);
+//! assert_eq!(val.get(&Some("next".to_string())).unwrap().raw_uri, "https://api.github.com/repositories/41986369/contributors?page=2");
+//! assert_eq!(val.get(&Some("last".to_string())).unwrap().raw_uri, "https://api.github.com/repositories/41986369/contributors?page=14");
 //! ```
 //!
 //! The parsed value is a `Result<HashMap<Option<Rel>, Link>, ()>`, which `Rel` and `Link` is:
@@ -49,7 +55,7 @@
 //!
 //! You can see why the key of `HashMap` is `Option<Rel>` because if you won't provide a `rel` type, the key will be an empty string.
 //!
-//! Refer to <https://tools.ietf.org/html/rfc8288#section-3.3>, **The rel parameter MUST be present**.
+//! Refer to <https://tools.ietf.org/html/rfc8288#section-3.3> (October 2017), **The rel parameter MUST be present**.
 //!
 //! Therefore, if you find that key is `None`, please check if you provide the `rel` type.
 


### PR DESCRIPTION
Update the documentation comment to provide a more meaningful code
example showing the results of a call to parse_link_header().

Also add the relevant data for RFC8288, as it may matter to those who
are trying to determine if the "rel" Relation Type will always be
present in the data they are trying to parse (or not).