### PR TITLE
Add proper type for Result<T, E>

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,12 +30,18 @@ parse_link_header = "0.2"
 Then:
 
 ```rust
-let link_header = "<https://api.github.com/repositories/41986369/contributors?page=2>; rel=\"next\", <https://api.github.com/repositories/41986369/contributors?page=14>; rel=\"last\"";
+let link_header = r#"<https://api.github.com/repositories/41986369/contributors?page=2>; rel="next", <https://api.github.com/repositories/41986369/contributors?page=14>; rel="last""#;
 
-parse_link_header::parse(link_header);
+let res = parse_link_header::parse(link_header);
+assert!(res.is_ok());
+
+let val = res.unwrap();
+assert_eq!(val.len(), 2);
+assert_eq!(val.get(&Some("next".to_string())).unwrap().raw_uri, "https://api.github.com/repositories/41986369/contributors?page=2");
+assert_eq!(val.get(&Some("last".to_string())).unwrap().raw_uri, "https://api.github.com/repositories/41986369/contributors?page=14");
 ```
 
-The parsed value is a `Result<HashMap<Option<Rel>, Link>, ()>`, which `Rel` and `Link` is:
+The parsed value is a `Result<HashMap<Option<Rel>, Link>, Error>`, which `Rel` and `Link` is:
 
 ```rust
 use std::collections::HashMap;
@@ -55,7 +61,7 @@ type Rel = String;
 
 You can see why the key of `HashMap` is `Option<Rel>` because if you won't provide a `rel` type, the key will be an empty string.
 
-Refer to <https://tools.ietf.org/html/rfc8288#section-3.3>, **the rel parameter MUST be present**.
+Refer to <https://tools.ietf.org/html/rfc8288#section-3.3> (October 2017), **the rel parameter MUST be present**.
 
 Therefore, if you find that key is `None`, please check if you provide the `rel` type.
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -35,7 +35,7 @@
 //! assert_eq!(val.get(&Some("last".to_string())).unwrap().raw_uri, "https://api.github.com/repositories/41986369/contributors?page=14");
 //! ```
 //!
-//! The parsed value is a `Result<HashMap<Option<Rel>, Link>, ()>`, which `Rel` and `Link` is:
+//! The parsed value is a `Result<HashMap<Option<Rel>, Link>, Error>`, which `Rel` and `Link` is:
 //!
 //! ```rust
 //! use std::collections::HashMap;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -310,4 +310,17 @@ mod tests {
 
         assert_eq!(expected, parsed);
     }
+
+    #[test]
+    fn test_error_display() {
+        assert_eq!(
+            format!("{}", Error(ErrorKind::InternalError)),
+            "internal parser error"
+        );
+
+        assert_eq!(
+            format!("{}", Error(ErrorKind::InvalidURI)),
+            "unable to parse URI component"
+        );
+    }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -82,6 +82,12 @@ pub enum ErrorKind {
 
     /// Failure to parse link value into URI
     InvalidURI,
+
+    /// Malformed parameters
+    MalformedParam,
+
+    /// Malformed URI query
+    MalformedQuery,
 }
 
 impl fmt::Display for Error {
@@ -89,6 +95,8 @@ impl fmt::Display for Error {
         match self.0 {
             ErrorKind::InternalError => write!(f, "internal parser error"),
             ErrorKind::InvalidURI => write!(f, "unable to parse URI component"),
+            ErrorKind::MalformedParam => write!(f, "malformed parameter list"),
+            ErrorKind::MalformedQuery => write!(f, "malformed URI query"),
         }
     }
 }
@@ -140,34 +148,32 @@ pub fn parse(link_header: &str) -> Result<LinkMap> {
         if let Some(query) = uri.query() {
             let mut query = query.to_string();
 
+            // skip leading ampersand
             if query.starts_with('&') {
                 query = query.chars().skip(1).collect();
             }
 
+            // split each query and extract as (key, value) pairs
             for q in query.split('&') {
-                let query_kv: Vec<&str> = q.split('=').collect();
+                let (key, val) = q.split_once('=').ok_or(Error(ErrorKind::MalformedQuery))?;
 
-                queries.insert(query_kv[0].to_string(), query_kv[1].to_string());
+                queries.insert(key.to_string(), val.to_string());
             }
         }
 
         let mut params = HashMap::new();
-        let mut rel = None;
 
+        // extract the parameter list as (key, value) pairs
         for param in link_vec {
-            let param_kv: Vec<&str> = param.split('=').collect();
-            let key = param_kv[0];
-            let val = param_kv[1];
-
-            if key == "rel" {
-                rel = Some(val.to_string());
-            }
+            let (key, val) = param
+                .split_once('=')
+                .ok_or(Error(ErrorKind::MalformedParam))?;
 
             params.insert(key.to_string(), val.to_string());
         }
 
         result.insert(
-            rel,
+            params.get("rel").cloned(),
             Link {
                 uri,
                 raw_uri,
@@ -321,6 +327,16 @@ mod tests {
         assert_eq!(
             format!("{}", Error(ErrorKind::InvalidURI)),
             "unable to parse URI component"
+        );
+
+        assert_eq!(
+            format!("{}", Error(ErrorKind::MalformedParam)),
+            "malformed parameter list"
+        );
+
+        assert_eq!(
+            format!("{}", Error(ErrorKind::MalformedQuery)),
+            "malformed URI query"
         );
     }
 }


### PR DESCRIPTION
`parse()` already returns a `Result<T, E>`, but `E` is only `()` and coveys no useful information.  Furthermore, `parse()` will `panic!()` upon hitting an error in a few places, making it difficult to handle errors at a higher-level.  This adds a real `struct Error` that implements trait `std::error::Error` and changes the code to use that value and avoid panics.

This should resolve #3 