### PR TITLE
Move regular expression compilation to `lazy_static!`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,3 +14,4 @@ license = "MIT"
 [dependencies]
 http = "0.2.1"
 regex = "1"
+lazy_static = "1.4.0"


### PR DESCRIPTION
Per the crate regex documentation, compiling a regular expression is expensive.  Move the regex building to inside a `lazy_static!` so it only gets done once, regardless of how many `Link:` headers are parsed.

This resolves #6 and needs to be applied on top of / after merge request #5 