### PR TITLE
Implement feature to use `url::Url` rather than `http::Uri`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,3 +15,4 @@ license = "MIT"
 http = "0.2.1"
 regex = "1"
 lazy_static = "1.4.0"
+url = {version = "2.2.2", optional = true }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,3 +14,4 @@ license = "MIT"
 [dependencies]
 http = "0.2.1"
 regex = "1"
+lazy_static = "1.4.0"

--- a/README.md
+++ b/README.md
@@ -65,6 +65,17 @@ Refer to <https://tools.ietf.org/html/rfc8288#section-3.3> (October 2017), **the
 
 Therefore, if you find that key is `None`, please check if you provide the `rel` type.
 
+# Feature: `url`
+
+If you enable the `url` feature, the `uri` field of struct [`Link`](struct.Link.html) will be
+of type url::Url from the [url crate](https://crates.io/crates/url), rather than the
+`http::Uri` it normally is.  This allows direct use of the `uri` field with other popular
+crates that use `url`, such as [`reqwest`](https://crates.io/crates/reqwest).
+
+**NOTE:** This implictly disabled support for relative refs, as URLs do not support relative
+refs (whereas URIs do).
+
+
 ## How to contribute
 
 Pull a request or open an issue to describe your changes or problems.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -58,10 +58,25 @@
 //! Refer to <https://tools.ietf.org/html/rfc8288#section-3.3> (October 2017), **the rel parameter MUST be present**.
 //!
 //! Therefore, if you find that key is `None`, please check if you provide the `rel` type.
+//!
+//! # Feature: `url`
+//!
+//! If you enable the `url` feature, the `uri` field of struct [`Link`](struct.Link.html) will be
+//! of type url::Url from the [url crate](https://crates.io/crates/url), rather than the
+//! `http::Uri` it normally is.  This allows direct use of the `uri` field with other popular
+//! crates that use `url`, such as [`reqwest`](https://crates.io/crates/reqwest).
+//!
+//! **NOTE:** This implictly disabled support for relative refs, as URLs do not support relative
+//! refs (whereas URIs do).
 
 use std::collections::HashMap;
 
+#[cfg(not(feature = "url"))]
 use http::Uri;
+
+#[cfg(feature = "url")]
+use url::Url as Uri;
+
 use std::fmt;
 
 /// A `Result` alias where the `Err` case is [`parse_link_header::Error`].
@@ -258,24 +273,27 @@ mod tests {
 
         assert_eq!(expected, parsed);
 
-        let mut rel_link_expected = HashMap::new();
+        #[cfg(not(feature = "url"))]
+        {
+            let mut rel_link_expected = HashMap::new();
 
-        rel_link_expected.insert(
-            Some("foo/bar".to_string()),
-            Link {
-                uri: "/foo/bar".parse().unwrap(),
-                raw_uri: "/foo/bar".to_string(),
-                queries: HashMap::new(),
-                params: [("rel".to_string(), "foo/bar".to_string())]
-                    .iter()
-                    .cloned()
-                    .collect(),
-            },
-        );
+            rel_link_expected.insert(
+                Some("foo/bar".to_string()),
+                Link {
+                    uri: "/foo/bar".parse().unwrap(),
+                    raw_uri: "/foo/bar".to_string(),
+                    queries: HashMap::new(),
+                    params: [("rel".to_string(), "foo/bar".to_string())]
+                        .iter()
+                        .cloned()
+                        .collect(),
+                },
+            );
 
-        let rel_link_parsed = parse("</foo/bar>; rel=\"foo/bar\"").unwrap();
+            let rel_link_parsed = parse(r#"</foo/bar>; rel="foo/bar""#).unwrap();
 
-        assert_eq!(rel_link_expected, rel_link_parsed);
+            assert_eq!(rel_link_expected, rel_link_parsed);
+        }
     }
 
     #[test]


### PR DESCRIPTION
This adds feature "url", which swaps the Uri for an URL.  This is useful, as many other packages use URLs rather than URIs, and it is often known ahead of time that the `Link` header contains a URL.

This resolves #8 and must be applied on top of #9 