### PR TITLE
Use version 1 of the 'http' crate

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -89,6 +89,8 @@ jobs:
           toolchain: nightly
       - name: Run cargo-tarpaulin
         uses: actions-rs/tarpaulin@v0.1
+        with:
+          version: '0.22.0'
       - uses: codecov/codecov-action@v2
         with:
           fail_ci_if_error: true # optional (default = false)

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ readme = "README.md"
 license = "MIT"
 
 [dependencies]
-http = "0.2.1"
+http = "1"
 regex = "1"
 lazy_static = "1.4.0"
 url = {version = "2.2.2", optional = true }


### PR DESCRIPTION
I also change the github pipeline as the "tarpaulin" action is looking for a "application/gzip" content type that is not provided by the latest version. I set the version to 0.22.0, the latest with a "application/gzip" content type.